### PR TITLE
Removed dependency on **MuMIn** and replaced with **AICcmodavg**

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: enmSdmX
 Type: Package
 Title: Species Distribution Modeling and Ecological Niche Modeling
-Version: 1.1.5
-Date: 2024-05-16
+Version: 1.1.6
+Date: 2024-06-06
 Authors@R: 
 	c(
 		person(
@@ -29,6 +29,7 @@ Description: Implements species distribution modeling and ecological niche
 Depends:
 	R (>= 4.0.0)
 Imports:
+	AICcmodavg,
 	boot,
 	data.table,
 	doParallel,
@@ -40,7 +41,6 @@ Imports:
 	maxnet,
 	methods,
 	mgcv,
-	MuMIn,
 	omnibus,
 	parallel,
 	predicts,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# enmSdmX 1.1.6 2024-06-06
+- Replaced dependency on **MuMIn** with one one **AICcmodavg** for calculation of AICc. Received warning that **MuMIn** was going to be archived on CRAN.
+
 # enmSdmX 1.1.5 2024-05-16
 - Added function `trainESM()` for ensembles of small models.
 - Added several UTM coordinate reference systems accessible through `getCRS()`.

--- a/R/interpolateRasts.r
+++ b/R/interpolateRasts.r
@@ -220,7 +220,7 @@ interpolateRasts <- function(
 						models[[length(models) + 1]] <- model
 						k <- c(k, length(model$coefficients))
 						
-						aicc <- sapply(models, MuMIn::AICc)
+						aicc <- sapply(models, AICcmodavg::AICc)
 						interpModel <- models[[which.min(aicc)]]
 
 					} else if (type == 'bs') {
@@ -251,7 +251,7 @@ interpolateRasts <- function(
 						models[[length(models) + 1]] <- model
 						k <- c(k, length(model$coefficients))
 						
-						aicc <- sapply(models, MuMIn::AICc)
+						aicc <- sapply(models, AICcmodavg::AICc)
 						interpModel <- models[[which.min(aicc)]]
 
 					} else if (type == 'smooth.spline') {
@@ -314,7 +314,7 @@ interpolateRasts <- function(
 							models[[length(models) + 1]] <- model
 							k <- c(k, length(model$coefficients))
 							
-							aicc <- sapply(models, MuMIn::AICc)
+							aicc <- sapply(models, AICcmodavg::AICc)
 							interpModel <- models[[which.min(aicc)]]
 							
 						}

--- a/R/trainGam.r
+++ b/R/trainGam.r
@@ -227,7 +227,7 @@ trainGAM <- function(
 				...
 			)
 			
-			AICc <- MuMIn::AICc(model)
+			AICc <- AICcmodavg::AICc(model)
 			
 			tuning <- data.frame(
 				model = form,
@@ -356,7 +356,7 @@ trainGAM <- function(
 			...
 		)
 		
-		AICc <- MuMIn::AICc(model)
+		AICc <- AICcmodavg::AICc(model)
 		
 		tuning <- data.frame(
 			model = form,
@@ -443,7 +443,7 @@ trainGAM <- function(
 		...
 	)
 	
-	AICc <- MuMIn::AICc(model)
+	AICc <- AICcmodavg::AICc(model)
 	
 	# out
 	out <- if (modelOut) {

--- a/R/trainGlm.r
+++ b/R/trainGlm.r
@@ -242,7 +242,7 @@ trainGLM <- function(
 				...
 			)
 			
-			AICc <- MuMIn::AICc(model)
+			AICc <- AICcmodavg::AICc(model)
 			
 			tuning <- data.frame(
 				model = form,
@@ -419,7 +419,7 @@ trainGLM <- function(
 			...
 		)
 		
-		AICc <- MuMIn::AICc(model)
+		AICc <- AICcmodavg::AICc(model)
 		
 		tuning <- data.frame(
 			model = form,
@@ -510,7 +510,7 @@ trainGLM <- function(
 		...
 	)
 	
-	AICc <- MuMIn::AICc(model)
+	AICc <- AICcmodavg::AICc(model)
 	
 	# out
 	if (modelOut) {

--- a/R/trainNs.r
+++ b/R/trainNs.r
@@ -336,7 +336,7 @@ trainNS <- function(
 		...
 	)
 	
-	AICc <- MuMIn::AICc(model)
+	AICc <- AICcmodavg::AICc(model)
 	
 	# out
 	out <- if (modelOut) {


### PR DESCRIPTION
From CRAN Team 2024-05-30:

We have asked for an update fixing the check problems shown at
  <https://cran.r-project.org/web/checks/check_results_MuMIn.html>
with no update from the maintainer thus far.

Thus, package MuMIn is now scheduled for archival on 2024-06-14, and
archiving this will necessitate also archiving its CRAN strong reverse
dependencies.

Please negotiate the necessary actions.

The CRAN Team