### PR TITLE
1.1.9

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,8 +1,8 @@
 Package: enmSdmX
 Type: Package
 Title: Species Distribution Modeling and Ecological Niche Modeling
-Version: 1.1.8
-Date: 2024-10-02
+Version: 1.1.9
+Date: 2024-11-01
 Authors@R: 
 	c(
 		person(

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# enmSdmX 1.1.9 2024-11-01
+- `trainGAM()` does not include interaction terms if `interaction` is `NULL`, and does not fail when interactions are included and the number of predictors is >2 (thank you, Pascal!).  
+
 # enmSdmX 1.1.8 2024-10-02
 - `modelSize()` can now tell size of a `ranger` random forest.
 

--- a/R/evalAUC.r
+++ b/R/evalAUC.r
@@ -7,6 +7,9 @@
 #' @param contrastWeight Weights of contrast cases. The default is to assign each case a weight of 1.
 #' @param na.rm Logical. If \code{TRUE} then remove any positive cases and associated weights and contrast predictions and associated weights with \code{NA}s.
 #' @param ... Other arguments (unused).
+#'
+#' @references Mason, S.J. and N.E. Graham.  2002.  Areas beneath the relative operating characteristics (ROC) and relative operating levels (ROL) curves: Statistical significance and interpretation.  \emph{Quarterly Journal of the Royal Meteorological Society} 128:2145-2166. \doi{10.1256/003590002320603584}
+#'
 #' @return A Numeric value.
 #'
 #' @seealso \code{\link[predicts]{pa_evaluate}}, \code{\link{evalMultiAUC}}

--- a/man/evalAUC.Rd
+++ b/man/evalAUC.Rd
@@ -51,6 +51,9 @@ evalAUC(pres, contrast, presWeight=presWeight)
 contrastWeight <- sqrt(contrast)
 evalAUC(pres, contrast, presWeight=presWeight, contrastWeight=contrastWeight)
 }
+\references{
+Mason, S.J. and N.E. Graham.  2002.  Areas beneath the relative operating characteristics (ROC) and relative operating levels (ROL) curves: Statistical significance and interpretation.  \emph{Quarterly Journal of the Royal Meteorological Society} 128:2145-2166. \doi{10.1256/003590002320603584}
+}
 \seealso{
 \code{\link[predicts]{pa_evaluate}}, \code{\link{evalMultiAUC}}
 }

--- a/man/trainGam.Rd
+++ b/man/trainGam.Rd
@@ -39,7 +39,7 @@ trainGAM(
 
 \item{smoothingBasis}{Character. Indicates the type of smoothing basis. The default is \code{'cs'} (cubic splines), but see \code{\link[mgcv]{smooth.terms}} for other options. This is the value of argument \code{bs} in a \code{\link[mgcv]{s}} function.}
 
-\item{interaction}{Character or \code{NULL}. Type of interaction term to use (\code{te}, \code{ts}, \code{s}, etc.). See \code{?te} (for example) for help on any one of these. If \code{NULL} then interactions are not used.}
+\item{interaction}{Character or \code{NULL}. Type of interaction term to use (\code{te}, \code{ts}, \code{s}, etc.). See \code{?te} (for example) for help on any one of these. If \code{NULL}, then interactions are not used.}
 
 \item{interceptOnly}{If \code{TRUE} (default) and model selection is enabled, then include an intercept-only model.}
 


### PR DESCRIPTION
# enmSdmX 1.1.9 2024-11-01
- `trainGAM()` does not include interaction terms if `interaction` is `NULL`, and does not fail when interactions are included and the number of predictors is >2 (thank you, Pascal!).  

