### PR TITLE
Work w factors w >2 levels; remove unconverged models

### DIFF
--- a/R/trainGlm.r
+++ b/R/trainGlm.r
@@ -26,7 +26,7 @@
 #' 	\item The name of the column in \code{data} that contains site weights.
 #' }
 #' @param removeInvalid Logical. If \code{TRUE} (default), remove models that either did not converge or have parameter estimates near the boundaries (usually negative or positive infinity). If you run this function with `construct = TRUE` (i.e., construct a "full" model from the best "small" models), then any small model that either did not converge or had parameters that are near the boundary (usually negative or positive infinity) are removed from consideration as terms in "full" model.
-#' @param failIfInvalid Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.
+#' @param failIfNoValid Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.
 #' @param out Character vector. One or more values:
 #' \itemize{
 #' 	\item	\code{'model'}: Model with the lowest AICc.
@@ -70,7 +70,7 @@ trainGLM <- function(
 	w = TRUE,
 	family = stats::binomial(),
 	removeInvalid = TRUE,
-	failIfInvalid = TRUE,
+	failIfNoValid = TRUE,
 	out = 'model',
 	cores = 1,
 	verbose = FALSE,
@@ -94,7 +94,7 @@ trainGLM <- function(
 		maxTerms <- 8
 		w <- TRUE
 		removeInvalid <- TRUE
-		failIfInvalid <- TRUE
+		failIfNoValid <- TRUE
 		scale <- TRUE
 		family <- stats::binomial()
 		out <- 'model'
@@ -211,7 +211,7 @@ trainGLM <- function(
 				
 				if (nrow(assess) == 0) {
 					msg <- 'No single-term models converged or all models had parameter estimates near the boundary.'
-					if (failIfInvalid) {
+					if (failIfNoValid) {
 						stop(msg)
 					} else {
 						warning(msg)
@@ -290,7 +290,7 @@ trainGLM <- function(
 				msg <- 'The model did not converge and/or estimates are near boundary conditions.'
 				if (removeInvalid) {
 				
-					if (failIfInvalid) {
+					if (failIfNoValid) {
 						stop(msg)
 					} else {
 						warning(msg)
@@ -453,7 +453,7 @@ trainGLM <- function(
 
 					if (nrow(tuning) == 0) {
 						msg <- 'No models converged or all had parameter estimates near the boundary of parameter space.'
-						if (failIfInvalid) {
+						if (failIfNoValid) {
 							stop(msg)
 						} else {
 							warning(msg)
@@ -519,7 +519,7 @@ trainGLM <- function(
 			msg <- 'The model did not converge and/or parameters are near the boundary space.'
 			if (removeInvalid) {
 				
-				if (failIfInvalid) {
+				if (failIfNoValid) {
 					stop(msg)
 				} else {
 					warning(msg)

--- a/R/trainNs.r
+++ b/R/trainNs.r
@@ -21,7 +21,7 @@
 #' }
 #' @param family Name of family for data error structure (see \code{\link[stats]{family}}).
 #' @param removeInvalid Logical. If \code{TRUE} (default), remove models that either did not converge or have parameter estimates near the boundaries (usually negative or positive infinity).
-#' @param failIfInvalid Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.
+#' @param failIfNoValid Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.
 #' @param out Character vector. One or more values:
 #' \itemize{
 #' 	\item	\code{'model'}: Model with the lowest AICc.
@@ -62,7 +62,7 @@ trainNS <- function(
 	w = TRUE,
 	family = 'binomial',
 	removeInvalid = TRUE,
-	failIfInvalid = TRUE,
+	failIfNoValid = TRUE,
 	out = 'model',
 	cores = 1,
 	verbose = FALSE,
@@ -83,7 +83,7 @@ trainNS <- function(
 		w <- TRUE
 		family <- 'binomial'
 		removeInvalid <- TRUE
-		failIfInvalid <- TRUE
+		failIfNoValid <- TRUE
 		out <- 'model'
 		cores <- 1
 		verbose <- TRUE
@@ -238,7 +238,7 @@ trainNS <- function(
 				
 				if (nrow(work) == 0) {
 					msg <- 'No single-term models converged or all models had parameter estimates near the boundary.'
-					if (failIfInvalid) {
+					if (failIfNoValid) {
 						stop(msg)
 					} else {
 						warning(msg)
@@ -357,7 +357,7 @@ trainNS <- function(
 				
 				if (nrow(work) == 0) {
 					msg <- 'No single-term models converged or all models had parameter estimates near the boundary.'
-					if (failIfInvalid) {
+					if (failIfNoValid) {
 						stop(msg)
 					} else {
 						warning(msg)

--- a/man/trainGlm.Rd
+++ b/man/trainGlm.Rd
@@ -21,7 +21,7 @@ trainGLM(
   w = TRUE,
   family = stats::binomial(),
   removeInvalid = TRUE,
-  failIfInvalid = TRUE,
+  failIfNoValid = TRUE,
   out = "model",
   cores = 1,
   verbose = FALSE,
@@ -67,7 +67,7 @@ trainGLM(
 
 \item{removeInvalid}{Logical. If \code{TRUE} (default), remove models that either did not converge or have parameter estimates near the boundaries (usually negative or positive infinity). If you run this function with `construct = TRUE` (i.e., construct a "full" model from the best "small" models), then any small model that either did not converge or had parameters that are near the boundary (usually negative or positive infinity) are removed from consideration as terms in "full" model.}
 
-\item{failIfInvalid}{Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.}
+\item{failIfNoValid}{Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.}
 
 \item{out}{Character vector. One or more values:
 \itemize{

--- a/man/trainNs.Rd
+++ b/man/trainNs.Rd
@@ -18,7 +18,7 @@ trainNS(
   w = TRUE,
   family = "binomial",
   removeInvalid = TRUE,
-  failIfInvalid = TRUE,
+  failIfNoValid = TRUE,
   out = "model",
   cores = 1,
   verbose = FALSE,
@@ -58,7 +58,7 @@ trainNS(
 
 \item{removeInvalid}{Logical. If \code{TRUE} (default), remove models that either did not converge or have parameter estimates near the boundaries (usually negative or positive infinity).}
 
-\item{failIfInvalid}{Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.}
+\item{failIfNoValid}{Logical. If \code{TRUE} (default), and the "full" model either does not converge or has parameters near the boundary, then the function will fail. If \code{FALSE}, then return \code{NULL} in this case.}
 
 \item{out}{Character vector. One or more values:
 \itemize{


### PR DESCRIPTION
# enmSdmX 1.2.10 2024-12-07
- `trainGLM()` now allows users to remove models that did not converge or had boundary problems. The function also works for factor predictors with > 2 levels. Thank you, A.L.!  
- `trainNS()` works when the number of predictors is >2 and interactions are allowed between variables. Thank you, P.T.! It also handles factors with >2 levels and allows users to remove models that did not converge or had boundary problems. Thank you, A.L.!
